### PR TITLE
feat(frontend): implement POPIA consent page and form

### DIFF
--- a/frontend/src/features/authentication/components/popia-consent-form.tsx
+++ b/frontend/src/features/authentication/components/popia-consent-form.tsx
@@ -23,10 +23,14 @@ function PopiaConsentForm() {
   return (
     <form
       onSubmit={handleSubmit}
-      className=" w-full max-w-[980px] h-[700px] bg-white rounded-2xl border px-20 py-14 flex flex-col mx-auto my-12"  style={{ borderColor:"var(--color-border)", }} >
+      className=" w-full max-w-[980px] min-h-[720px] bg-white rounded-2xl border px-20 py-14 flex flex-col mx-auto my-12"  style={{ borderColor:"var(--color-border)", }} >
       <div className="flex flex-col gap-6">
+        <div
+        className="flex justify-center mb-8">
+        <div className="w-[115px]" />
+       </div>
       {/* Header */}
-      <div className="text-center mb-0">
+      <div className="text-center mb-2">
         <h1
           className=" text-4xl font-bold mb-4 " style={{ color: "var(--color-primary)", }} >
           Welcome to ConsultIQ
@@ -39,7 +43,7 @@ function PopiaConsentForm() {
       </div>
 
       {/* Scrollable Content */}
-      <div className="w-full max-h-[420px] overflow-y-auto px-6 flex flex-col items-center gap-10">
+      <div className="w-full max-h-[420px] overflow-y-auto px-6 flex flex-col items-center gap-6">
         {/* User Rights Section */}
         <div className="w-full max-w-[760px]">
           <h2
@@ -103,47 +107,53 @@ function PopiaConsentForm() {
         </div>
       </div>
 
-      <div className="w-full max-w-[760px] mx-auto mt-0">
-      {/* Checkbox */}
-      <div
-        className="flex items-start gap-4">
+<div className="w-full max-h-[420px] mt-0 px-6 flex flex-col items-center gap-6">
+    
+    {/* Checkbox + Label */}
+    <div className="flex items-start justify-center gap-4 max-w-[760px]">
         <input
-          type="checkbox"
-          id="consent"
-          checked={accepted}
-          onChange={(e) =>
-            setAccepted(e.target.checked)}
-          className="w-5 h-5 mt-1 accent-[var(--color-primary)] "/>
+            type="checkbox"
+            id="consent"
+            checked={accepted}
+            onChange={(e) => setAccepted(e.target.checked)}
+            className="w-5 h-5 mt-1 accent-[var(--color-primary)] shrink-0"
+        />
 
         <label
-          htmlFor="consent"
-          className="text-base leading-"
-          style={{color:"var(--color-text-primary)",}}>
-          I acknowledge that I have read and understood the POPIA consent policy and consent
-          to the processing of my personal information in accordance with applicable regulations.
+            htmlFor="consent"
+            className="text-base leading-7 flex-1"
+            style={{ color: "var(--color-text-primary)" }}
+        >
+            I acknowledge that I have read and understood the POPIA consent policy
+            and consent to the processing of my personal information in accordance
+            with applicable regulations.
         </label>
-      </div>
+    </div>
 
-      {/* Buttons */}
-      <div
-        className="flex justify-center gap-6 mt-2 ">
+    {/* Buttons */}
+    <div className="flex justify-center gap-6 mt-6">
         <button
-          type="submit" disabled={!accepted} className=" min-w-[220px] h-[56px] rounded-lg
-            text-white font-bold text-lg transition hover:brightness-110 disabled:opacity-50
-            disabled:cursor-not-allowed"
-          style={{ backgroundColor: "var(--color-primary)", }}>
-          Accept & Continue
+            type="submit"
+            disabled={!accepted}
+            className="min-w-[220px] h-[56px] rounded-lg text-white font-bold text-lg transition hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ backgroundColor: "var(--color-primary)" }}
+        >
+            Accept & Continue
         </button>
 
         <button
-          type="button"
-          onClick={handleDecline}
-          className="min-w-[220px] h-[56px] rounded-lg border font-bold text-lg transition bg-gray-50 hover:bg-gray-100"
-          style={{borderColor: "var(--color-border)", color:"var(--color-text-primary)",}}>
-          Decline
+            type="button"
+            onClick={handleDecline}
+            className="min-w-[220px] h-[56px] rounded-lg border font-bold text-lg transition bg-gray-50 hover:bg-gray-100"
+            style={{
+                borderColor: "var(--color-border)",
+                color: "var(--color-text-primary)",
+            }}
+        >
+            Decline
         </button>
-        </div>
-      </div>
+    </div>
+</div>
       </div>
     </form>
   );

--- a/frontend/src/features/authentication/components/popia-consent-form.tsx
+++ b/frontend/src/features/authentication/components/popia-consent-form.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+
+function PopiaConsentForm() {
+  const [accepted, setAccepted] =
+    useState(false);
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!accepted) {
+      return;
+    }
+    // TODO: API call to save consent
+    console.log(
+      "POPIA consent accepted"
+    );
+  }
+
+  function handleDecline() {
+    // TODO: redirect
+    console.log("POPIA consent declined");
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className=" w-full max-w-[980px] h-[700px] bg-white rounded-2xl border px-20 py-14 flex flex-col mx-auto my-12"  style={{ borderColor:"var(--color-border)", }} >
+      <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="text-center mb-0">
+        <h1
+          className=" text-4xl font-bold mb-4 " style={{ color: "var(--color-primary)", }} >
+          Welcome to ConsultIQ
+        </h1>
+
+        <p
+          className="text-lg" style={{ color: "var(--color-text-secondary)", }}>
+          Before we proceed, please read and accept our POPIA consent policy.
+        </p>
+      </div>
+
+      {/* Scrollable Content */}
+      <div className="w-full max-h-[420px] overflow-y-auto px-6 flex flex-col items-center gap-10">
+        {/* User Rights Section */}
+        <div className="w-full max-w-[760px]">
+          <h2
+            className=" text-2xl font-bold mb-4 " style={{ color: "var(--color-primary)", }} >
+            User Rights
+          </h2>
+
+          <p
+            className=" text-lg leading-8 " style={{ color:"var(--color-text-secondary)", }} >
+            In accordance with the Protection of Personal Information Act (POPIA), you have the right to
+            access, update, and request deletion of your personal information. ConsultIQ is committed to ensuring
+            transparency in how your information is collected, processed, and stored within the system.
+          </p>
+        </div>
+
+        {/* Information Usage Section */}
+        <div className="w-full max-w-[760px]">
+          <h2
+            className=" text-2xl font-bold mb-4 " style={{ color: "var(--color-primary)", }} >
+            Information Usage
+          </h2>
+
+          <p
+            className="text-lg leading-8" style={{color: "var(--color-text-secondary)", }}>
+            Your information will be used solely for consultant management, project placement, communication,
+            and platform-related operations. ConsultIQ will never sell or distribute your personal information
+            to unauthorized third parties.
+          </p>
+        </div>
+
+        {/*Data Security  Section */}
+        <div className="w-full max-w-[760px]">
+          <h2
+            className=" text-2xl font-bold mb-4 "style={{color:"var(--color-primary)",}} >
+            Data Security
+          </h2>
+
+          <p
+            className=" text-lg leading-8 "
+            style={{ color:"var(--color-text-secondary)",}}>
+            ConsultIQ applies industry standard security measures to protect all personal and operational data.
+            Access to sensitive information is restricted based on role-based access controls, and all data is
+            encrypted and securely stored.
+          </p>
+        </div>
+
+        {/* Consent Agreement Section */}
+        <div className="w-full max-w-[760px]">
+          <h2
+            className=" text-2xl font-bold mb-4"
+            style={{ color: "var(--color-primary)", }} >
+            Consent Agreement
+          </h2>
+
+          <p
+            className="text-lg leading-8 "
+            style={{ color:"var(--color-text-secondary)", }}>
+            By accepting this policy, you consent to the collection, processing, and storage of your personal
+            information as outlined above and in accordance with POPIA regulations.
+          </p>
+        </div>
+      </div>
+
+      <div className="w-full max-w-[760px] mx-auto mt-0">
+      {/* Checkbox */}
+      <div
+        className="flex items-start gap-4">
+        <input
+          type="checkbox"
+          id="consent"
+          checked={accepted}
+          onChange={(e) =>
+            setAccepted(e.target.checked)}
+          className="w-5 h-5 mt-1 accent-[var(--color-primary)] "/>
+
+        <label
+          htmlFor="consent"
+          className="text-base leading-"
+          style={{color:"var(--color-text-primary)",}}>
+          I acknowledge that I have read and understood the POPIA consent policy and consent
+          to the processing of my personal information in accordance with applicable regulations.
+        </label>
+      </div>
+
+      {/* Buttons */}
+      <div
+        className="flex justify-center gap-6 mt-2 ">
+        <button
+          type="submit" disabled={!accepted} className=" min-w-[220px] h-[56px] rounded-lg
+            text-white font-bold text-lg transition hover:brightness-110 disabled:opacity-50
+            disabled:cursor-not-allowed"
+          style={{ backgroundColor: "var(--color-primary)", }}>
+          Accept & Continue
+        </button>
+
+        <button
+          type="button"
+          onClick={handleDecline}
+          className="min-w-[220px] h-[56px] rounded-lg border font-bold text-lg transition bg-gray-50 hover:bg-gray-100"
+          style={{borderColor: "var(--color-border)", color:"var(--color-text-primary)",}}>
+          Decline
+        </button>
+        </div>
+      </div>
+      </div>
+    </form>
+  );
+}
+
+export default PopiaConsentForm;

--- a/frontend/src/features/authentication/pages/popia-consent-page.tsx
+++ b/frontend/src/features/authentication/pages/popia-consent-page.tsx
@@ -1,0 +1,21 @@
+import PopiaConsentForm from "../components/popia-consent-form";
+
+function PopiaConsentPage() {
+  return (
+    <div
+      className="
+        min-h-screen
+        bg-[var(--color-surface)]
+        flex
+        items-center
+        justify-center
+        px-8 
+        py-12
+      "
+    >
+      <PopiaConsentForm />
+    </div>
+  );
+}
+
+export default PopiaConsentPage;

--- a/frontend/src/routes/app-routes.tsx
+++ b/frontend/src/routes/app-routes.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import RegisterUserPage from "../features/authentication/pages/register-user-page";
 import SetPasswordPage from "../features/authentication/pages/set-password-page";
+import PopiaConsentPage from "../features/authentication/pages/popia-consent-page";
 
 function AppRoutes() {
     return (
@@ -9,6 +10,7 @@ function AppRoutes() {
         <Routes>
             <Route path="/register" element={<RegisterUserPage />} />
             <Route path="/set-password" element={<SetPasswordPage />} />
+            <Route path="/popia-consent" element={<PopiaConsentPage />} />
         </Routes>
         </BrowserRouter>
     );


### PR DESCRIPTION
## Summary

Implemented the POPIA consent screen for ConsultIQ onboarding.

This page is displayed before users continue into the platform and allows them to review and accept the POPIA consent policy.

## Changes Made

### Added POPIA Consent Page
- Created `PopiaConsentPage.tsx`

### Added POPIA Consent Form
- Created `popia-consent-form.tsx`
- Added:
  - Policy sections
  - Consent acknowledgement checkbox
  - Accept & Continue button
  - Decline button
- Added disabled state until consent is checked

## Notes
- Backend integration for storing consent acceptance will be added separately.