### PR TITLE
fix: update routing

### DIFF
--- a/backend/src/auth/services/auth.service.ts
+++ b/backend/src/auth/services/auth.service.ts
@@ -35,10 +35,10 @@ export interface LoginResult {
 
 /** Map role -> frontend route  */
 const ROLE_DASHBOARD_MAP: Record<Role, string> = {
-  ADMIN: '/admin',
+  ADMIN: '/register',
   PROJECT_MANAGER: '/projects',
-  CONSULTANT_MANAGER: '/consultant-profiles',
-  CONSULTANT: '/profile',
+  CONSULTANT_MANAGER: '/consultants-manager',
+  CONSULTANT: '/consultant-profile',
 };
 
 class TooManyRequestsException extends HttpException {

--- a/frontend/src/context/use-auth.ts
+++ b/frontend/src/context/use-auth.ts
@@ -1,8 +1,1 @@
-import { useContext } from "react";
-import { AuthContext } from "./auth-context";
-
-export const useAuth = () => {
-  const context = useContext(AuthContext);
-  if (!context) throw new Error("useAuth must be used within AuthProvider");
-  return context;
-};
+export { useAuth } from "../hooks/useAuth";

--- a/frontend/src/features/authentication/services/auth.service.ts
+++ b/frontend/src/features/authentication/services/auth.service.ts
@@ -1,4 +1,4 @@
-import type { LoginPayload, LoginResponse, LoginResult } from '../types/auth.types';
+import type { LoginPayload, LoginResult } from '../types/auth.types';
 import { apiClient } from '../../../lib/api-client';
 
 const API_BASE_URL = 'http://localhost:3000';
@@ -34,13 +34,13 @@ async function handleResponse<T>(res: Response): Promise<T> {
 }
 
 export const authService = {
-    login: (payload: LoginPayload): Promise<LoginResponse> =>
+    login: (payload: LoginPayload): Promise<{ message: string; result: LoginResult }> =>
         fetch(`${API_BASE_URL}/auth/login`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',
             body: JSON.stringify(payload),
-        }).then((res) => handleResponse<LoginResponse>(res)),
+        }).then((res) => handleResponse<{ message: string; result: LoginResult }>(res)),
     getProfile: async (): Promise<Omit<LoginResult, 'accessToken' | 'refreshToken'>> => {
         // Hits your /auth/me endpoint 
         const response = await apiClient.get<{ result: Omit<LoginResult, 'accessToken' | 'refreshToken'> }>('/auth/me');

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -59,9 +59,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     // Login processor
     const login = useCallback(async (payload: LoginPayload) => {
+        // The backend wraps the response in a result object via a global interceptor
         const response = await authService.login(payload);
 
-        if (response && response.result) {
+        if (response && response.result && response.result.accessToken) {
             const { accessToken, refreshToken, ...userProfile } = response.result;
 
             // Persist tokens across page reloads in sessionStorage
@@ -74,7 +75,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             // Return dashboard route to let the Login page wrap up routing
             return userProfile.dashboardRoute;
         } else {
-            console.error('Backend response structure is unexpected:', response);
+            console.error('Login failed or backend response structure is unexpected:', response);
             throw new Error('Malformed response structure from authentication server.');
         }
     }, []);

--- a/frontend/src/routes/app-routes.tsx
+++ b/frontend/src/routes/app-routes.tsx
@@ -14,10 +14,12 @@ import CreateProfilePage from "../features/consultants/pages/create-profile-page
 
 // Route Guard
 import { ProtectedRoute } from "./protected-route";
+import { AuthProvider } from "../hooks/useAuth";
 
 function AppRoutes() {
     return (
-        <BrowserRouter>
+        <AuthProvider>
+            <BrowserRouter>
             <Routes>
                 {/* ------------------------------------------- */}
                 {/* PUBLIC ROUTES (Accessible to anyone)        */}
@@ -40,7 +42,8 @@ function AppRoutes() {
                 {/* Catch-all: Redirect unknown URLs to login */}
                 <Route path="*" element={<Navigate to="/login" replace />} />
             </Routes>
-        </BrowserRouter>
+            </BrowserRouter>
+        </AuthProvider>
     );
 }
 


### PR DESCRIPTION
  - Wrapped `AppRoutes` with `<AuthProvider>` to fix "useAuth must be used inside AuthProvider" errors.
  - Updated `useAuth` and `auth.service.ts` to correctly parse the nested `{ message, result }` response payload from the backend interceptor.
  - Updated role-based dashboard routes in the backend `AuthService` to point to the correct frontend screens (`/consultant-manager` and `/consultant-profile`).
  - Fixed a legacy context import in `src/context/use-auth.ts` by re-exporting the correct hook.